### PR TITLE
Add SSH bastion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
-
+*.pem
 website/vendor
 
 # Test exclusions

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ data "port_scan" "nomad_server" {
     user        = "ubuntu"
     ip_address  = "34.75.85.111"
     private_key = file("private_key.pem")
+
+    insecure_ignore_host_key = true
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ Outputs:
 open_ports = []
 ```
 
+## SSH Bastion Support
+
+When the hosts aren't publicly available, we can use an SSH bastion jump-box for port scanning.
+
+For example, after using the [`picatz/terraform-google-nomad`](https://github.com/picatz/terraform-google-nomad) provider, we can verify the Nomad server is up through the SSH bastion:
+
+```hcl
+data "port_scan" "example" {
+  ip_address = "192.168.2.2"
+  port       = 4646
+
+    ssh_bastion {
+        user        = "ubuntu"
+        ip_address  = "34.75.85.111"
+        private_key = file("private_key.pem")
+    }
+}
+
+output "open_ports" {
+  value = data.port_scan.example.open_ports
+}
+```
+
 ## Building the Provider
 
 The following steps will create a `terraform-provider-port` executable:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ output "open_ports" {
 }
 ```
 
+> **Note**: Try to use single ports (or small port ranges), as large port scan ranges will take a long time, since the connect timeout to the internal IP address is controlled by the SSH bastion server itself. To speed this up requires using a custom SSH server that adds a small (or configurable) timeout to the `direct-tcpip` channel type. A configurable timeout may break other SSH server's assumptions about the channel open direct message described in [`RFC 4254 7.2`](https://tools.ietf.org/html/rfc4254#section-7.2).
+
 ## Building the Provider
 
 The following steps will create a `terraform-provider-port` executable:

--- a/README.md
+++ b/README.md
@@ -36,22 +36,27 @@ open_ports = []
 
 When the hosts aren't publicly available, we can use an SSH bastion jump-box for port scanning.
 
-For example, after using the [`picatz/terraform-google-nomad`](https://github.com/picatz/terraform-google-nomad) provider, we can verify the Nomad server is up through the SSH bastion:
+For example, after using the [`picatz/terraform-google-nomad`](https://github.com/picatz/terraform-google-nomad) provider, we can verify the Nomad server (`192.168.2.2`) is up through the SSH bastion:
 
 ```hcl
-data "port_scan" "example" {
+data "port_scan" "nomad_server" {
   ip_address = "192.168.2.2"
-  port       = 4646
+  ports = [
+    22,
+    4648,
+    4647,
+    4646,
+  ]
 
-    ssh_bastion {
-        user        = "ubuntu"
-        ip_address  = "34.75.85.111"
-        private_key = file("private_key.pem")
-    }
+  ssh_bastion {
+    user        = "ubuntu"
+    ip_address  = "34.75.85.111"
+    private_key = file("private_key.pem")
+  }
 }
 
 output "open_ports" {
-  value = data.port_scan.example.open_ports
+  value = data.port_scan.nomad_server.open_ports
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.14
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.12.0
+	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/internal/provider/data_source_ports_scan.go
+++ b/internal/provider/data_source_ports_scan.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	scanner "github.com/picatz/terraform-provider-port-scan/internal/provider/port-scanner"
@@ -47,8 +46,6 @@ func dataSourcePortScan() *schema.Resource {
 }
 
 func dataSourcePortScanRead(d *schema.ResourceData, meta interface{}) error {
-	log.Println("[DEBUG] performing port scan")
-
 	// Note: this took me FOREVER to figure out I needed to set an ID...
 	//       so everything would seemingly almost work, but the attributes
 	//       would never get set!
@@ -80,8 +77,6 @@ func dataSourcePortScanRead(d *schema.ResourceData, meta interface{}) error {
 			openPorts = append(openPorts, result.Port)
 		}
 	}
-
-	log.Printf("[DEBUG] found %d open ports", len(openPorts))
 
 	return d.Set("open_ports", openPorts)
 }

--- a/internal/provider/data_source_ports_scan.go
+++ b/internal/provider/data_source_ports_scan.go
@@ -70,9 +70,13 @@ func dataSourcePortScanRead(d *schema.ResourceData, meta interface{}) error {
 		toPort = d.Get("to_port").(int)
 	}
 
+	// default dialer
+	var dialer scanner.Dialer = scanner.DefaultDialer
+	defer dialer.Close()
+
 	openPorts := []int{}
 
-	for result := range scanner.Run(context.Background(), ipAddress, fromPort, toPort, scanner.DefaultTimeoutPerPort) {
+	for result := range scanner.Run(dialer, ipAddress, fromPort, toPort, scanner.DefaultTimeoutPerPort) {
 		if result.Open {
 			openPorts = append(openPorts, result.Port)
 		}

--- a/internal/provider/data_source_ports_scan.go
+++ b/internal/provider/data_source_ports_scan.go
@@ -85,3 +85,11 @@ func dataSourcePortScanRead(d *schema.ResourceData, meta interface{}) error {
 
 	return d.Set("open_ports", openPorts)
 }
+
+func sshKey(key string) (ssh.AuthMethod, error) {
+	signer, err := ssh.ParsePrivateKey([]byte(key))
+	if err != nil {
+		return nil, err
+	}
+	return ssh.PublicKeys(signer), nil
+}

--- a/internal/provider/data_source_ports_scan_test.go
+++ b/internal/provider/data_source_ports_scan_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const testDataSourceUnknownKeyError = `
-data "ports_scan" "example" {
+data "port_scan" "example" {
 	this_doesnt_exist = "foo"
 }
 `
@@ -38,7 +38,7 @@ func TestDataSource_compileUnknownKeyError(t *testing.T) {
 }
 
 const testDataSourceLocalhost5959 = `
-data "ports_scan" "example" {
+data "port_scan" "example" {
 	ip_address = "127.0.0.1"
 	port       = 5959
 }

--- a/internal/provider/port-scanner/scanner.go
+++ b/internal/provider/port-scanner/scanner.go
@@ -73,10 +73,6 @@ func ulimit() int64 {
 }
 
 func scanPort(d Dialer, ip string, port int, timeout time.Duration) (result PortScanResult) {
-	if timeout == 0 {
-		timeout = DefaultTimeoutPerPort
-	}
-
 	result.IP = ip
 	result.Port = port
 

--- a/internal/provider/port-scanner/scanner.go
+++ b/internal/provider/port-scanner/scanner.go
@@ -137,35 +137,40 @@ type SSHBastionScanner struct {
 
 // DialTimeout implements the Dialer interface
 func (b *SSHBastionScanner) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
-	ctx, cancel := context.WithTimeout(b.ctx, timeout)
-	defer cancel()
+	// ctx, cancel := context.WithTimeout(b.ctx, timeout)
+	// defer cancel()
 
 	connChan := make(chan net.Conn, 1)
 	errChan := make(chan error, 1)
 
 	go func() {
+		// log.Printf("[DEBUG] dialing %s", address)
+		// defer log.Printf("[DEBUG] done dialing %s", address)
 		conn, err := b.Client.Dial(network, address)
 		if err != nil {
 			select {
-			case <-ctx.Done():
+			// case <-ctx.Done():
 			case errChan <- err:
 			}
 			return
 		}
 
 		select {
-		case <-ctx.Done():
-			conn.Close()
+		//case <-ctx.Done():
+		//	conn.Close()
 		case connChan <- conn:
 		}
 	}()
 
 	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	// case <-ctx.Done():
+	// 	log.Printf("[DEBUG] ctx done %s", address)
+	// 	return nil, ctx.Err()
 	case conn := <-connChan:
+		// log.Printf("[DEBUG] got conn %s", address)
 		return conn, nil
 	case err := <-errChan:
+		// log.Printf("[DEBUG] got err %s %q", address, err.Error())
 		return nil, err
 	}
 }

--- a/internal/provider/port-scanner/scanner.go
+++ b/internal/provider/port-scanner/scanner.go
@@ -29,7 +29,20 @@ type PortScanResult struct {
 // DefaultTimeoutPerPort is the default timeout per-port for Run
 var DefaultTimeoutPerPort = time.Second * 5
 
-var d net.Dialer
+type defaultDialer struct {
+	net.Dialer
+}
+
+func (d defaultDialer) Dial(network, address string) (net.Conn, error) {
+	return d.Dialer.Dial(network, address)
+}
+
+func (d defaultDialer) Close() error {
+	return nil
+}
+
+// DefaultDialer is the default dialer.
+var DefaultDialer = defaultDialer{}
 
 var lock *semaphore.Weighted = semaphore.NewWeighted(ulimit())
 

--- a/internal/provider/port-scanner/scanner.go
+++ b/internal/provider/port-scanner/scanner.go
@@ -122,6 +122,7 @@ func Run(d Dialer, ip string, firstPort, lastPort int, timeoutPerPort time.Durat
 	return results
 }
 
+// SSHBastionScanner is a Dialer that uses an SSH bastion to establish connections for the port scan.
 type SSHBastionScanner struct {
 	Conn           net.Conn
 	Client         *ssh.Client
@@ -130,6 +131,7 @@ type SSHBastionScanner struct {
 	timeOutPerPort time.Duration
 }
 
+// DialTimeout implements the Dialer interface
 func (b *SSHBastionScanner) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
 	ctx, cancel := context.WithTimeout(b.ctx, timeout)
 	defer cancel()
@@ -164,11 +166,13 @@ func (b *SSHBastionScanner) DialTimeout(network, address string, timeout time.Du
 	}
 }
 
+// Close implements the Dialer interface
 func (b *SSHBastionScanner) Close() error {
 	b.cancel()
 	return nil
 }
 
+// NewSSHBastionScanner creates a new SSHBastionScanner Dialer type
 func NewSSHBastionScanner(addr string, config *ssh.ClientConfig) (Dialer, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/internal/provider/port-scanner/scanner.go
+++ b/internal/provider/port-scanner/scanner.go
@@ -12,6 +12,12 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+// Dialer implents an interface to allow for multiple network connection types
+type Dialer interface {
+	Dial(network, address string) (net.Conn, error)
+	Close() error
+}
+
 // PortScanResult is the type returned by the Run func result chan
 type PortScanResult struct {
 	IP    string

--- a/internal/provider/port-scanner/scanner.go
+++ b/internal/provider/port-scanner/scanner.go
@@ -81,12 +81,20 @@ func scanPort(d Dialer, ip string, port int, timeout time.Duration) (result Port
 	conn, err := d.DialTimeout("tcp", target, timeout)
 	if err != nil {
 		if strings.Contains(err.Error(), "too many open files") {
-			time.Sleep(timeout)
-			scanPort(d, ip, port, timeout)
+			for {
+				time.Sleep(timeout)
+				conn, err = d.DialTimeout("tcp", target, timeout)
+				if strings.Contains(err.Error(), "too many open files") {
+					continue
+				} else {
+					result.Error = err
+					return
+				}
+			}
 		} else {
 			result.Error = err
+			return
 		}
-		return
 	}
 	conn.Close()
 	result.Open = true

--- a/internal/provider/port-scanner/scanner_test.go
+++ b/internal/provider/port-scanner/scanner_test.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"testing"
@@ -31,7 +30,10 @@ func Test_scanPort_open(t *testing.T) {
 		time.Sleep(10 * time.Second)
 	}()
 
-	scanPort(context.Background(), "127.0.0.1", port, DefaultTimeoutPerPort)
+	result := scanPort(DefaultDialer, "127.0.0.1", port, DefaultTimeoutPerPort)
+	if !result.Open {
+		t.Fatalf("Expected port %d to be open", port)
+	}
 }
 
 func Test_scanPort_closed(t *testing.T) {
@@ -43,7 +45,10 @@ func Test_scanPort_closed(t *testing.T) {
 	}
 	listener.Close()
 
-	scanPort(context.Background(), "127.0.0.1", port, DefaultTimeoutPerPort)
+	result := scanPort(DefaultDialer, "127.0.0.1", port, DefaultTimeoutPerPort)
+	if result.Open {
+		t.Fatalf("Expected port %d to be closed", port)
+	}
 }
 
 func Test_scanPort_Run(t *testing.T) {
@@ -64,7 +69,7 @@ func Test_scanPort_Run(t *testing.T) {
 		time.Sleep(10 * time.Second)
 	}()
 
-	for result := range Run(context.Background(), "127.0.0.1", 5000, 6000, DefaultTimeoutPerPort) {
+	for result := range Run(DefaultDialer, "127.0.0.1", 5000, 6000, DefaultTimeoutPerPort) {
 		if result.Port == port {
 			if !result.Open {
 				t.Fatalf("Expected open port %d to be open, but was closed", port)
@@ -95,7 +100,7 @@ func Test_scanPort_Run_sameFromAndToPort(t *testing.T) {
 		time.Sleep(10 * time.Second)
 	}()
 
-	for result := range Run(context.Background(), "127.0.0.1", 5959, 5959, DefaultTimeoutPerPort) {
+	for result := range Run(DefaultDialer, "127.0.0.1", 5959, 5959, DefaultTimeoutPerPort) {
 		if result.Port == port {
 			if !result.Open {
 				t.Fatalf("Expected open port %d to be open, but was closed", port)

--- a/internal/provider/port-scanner/scanner_test.go
+++ b/internal/provider/port-scanner/scanner_test.go
@@ -1,10 +1,19 @@
 package scanner
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/subtle"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"log"
 	"net"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/ssh"
 )
 
 func Test_ulimit(t *testing.T) {
@@ -111,4 +120,184 @@ func Test_scanPort_Run_sameFromAndToPort(t *testing.T) {
 			}
 		}
 	}
+}
+
+func Test_scanPort_Run_withSSHBastion(t *testing.T) {
+	// setp fake service on localhost
+	serviceReady := make(chan bool, 1)
+
+	port := 5959
+
+	go func() {
+		listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			panic(err)
+		}
+		defer listener.Close()
+		serviceReady <- true
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Log(err)
+			return
+		}
+		defer conn.Close()
+		time.Sleep(10 * time.Second)
+	}()
+
+	// setup test SSH server on localhost:2222
+
+	serverReady := make(chan bool, 1)
+
+	go func() {
+		private, err := genRSASSHHostKey()
+		if err != nil {
+			panic(err)
+		}
+
+		config := &ssh.ServerConfig{
+			PasswordCallback: func(conn ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
+				if conn.User() != "root" {
+					return nil, fmt.Errorf("not root user")
+				}
+				if subtle.ConstantTimeCompare([]byte("password"), password) != 1 {
+					return nil, fmt.Errorf("bad password")
+				}
+				return nil, nil
+			},
+		}
+
+		config.AddHostKey(private)
+
+		log.Println("Starting test SSH server")
+		listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:2222"))
+		if err != nil {
+			panic(err)
+		}
+		defer listener.Close()
+
+		log.Println("Accepting SSH connection")
+		serverReady <- true
+		conn, err := listener.Accept()
+		log.Println("Accepted SSH connection")
+
+		log.Println("Performing SSH handshake")
+		sshConn, chans, reqs, err := ssh.NewServerConn(conn, config)
+		if err != nil {
+			panic(err)
+		}
+		if err != nil {
+			panic(err)
+		}
+		defer sshConn.Close()
+
+		go ssh.DiscardRequests(reqs)
+
+		log.Println("Serving SSH channel reqs")
+		for newChan := range chans {
+			if newChan.ChannelType() != "direct-tcpip" {
+				log.Printf("New direct-tcpip chan req %#+v", newChan)
+				panic(fmt.Sprintf("Expected new chan req to be 'direct-tcpip', got %q", newChan.ChannelType()))
+			}
+
+			msg := channelOpenDirectMsg{}
+
+			err := ssh.Unmarshal(newChan.ExtraData(), &msg)
+			if err != nil {
+				panic(err)
+			}
+
+			log.Printf("channelOpenDirectMsg %#+v", msg)
+
+			// spot check
+
+			// the request remote addr to connect to should be localhost
+			if msg.Raddr != "127.0.0.1" {
+				panic(fmt.Sprintf("Unexpect remote address request: %#+v", msg.Raddr))
+			}
+
+			// the request remote port to connect to should be 5959
+			if int(msg.Rport) != 5959 {
+				panic(fmt.Sprintf("Unexpect remote port request: %#+v", msg.Rport))
+			}
+
+			// perform connection
+			conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", msg.Raddr, int(msg.Rport)), time.Second*10)
+			if err != nil {
+				panic(err)
+			}
+			conn.Close()
+
+			// Accepting the channel is enough to pass the test!
+			acceptedChan, chanReqs, err := newChan.Accept()
+			if err != nil {
+				panic(err)
+			}
+			defer acceptedChan.Close()
+
+			for req := range chanReqs {
+				log.Printf("New direct-tcpip nested chan req %#+v", req)
+			}
+		}
+
+		time.Sleep(10 * time.Second)
+
+		log.Println("Closing SSH server")
+	}()
+
+	<-serverReady
+	<-serviceReady
+
+	sshBastionDialer, err := NewSSHBastionScanner("127.0.0.1:2222", &ssh.ClientConfig{
+		User:            "root",
+		Auth:            []ssh.AuthMethod{ssh.Password("password")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for result := range Run(sshBastionDialer, "127.0.0.1", 5959, 5959, DefaultTimeoutPerPort) {
+		if result.Port == port {
+			if !result.Open {
+				t.Fatalf("Expected open port %d to be open, but was closed", port)
+			}
+		} else {
+			if result.Open {
+				t.Errorf("Unexpected open port %d", port)
+			}
+		}
+	}
+}
+
+// RFC 4254 7.2
+type channelOpenDirectMsg struct {
+	Raddr string
+	Rport uint32
+	Laddr string
+	Lport uint32
+}
+
+func genRSASSHHostKey() (ssh.Signer, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	privKeyPEMBuffer := new(bytes.Buffer)
+	err = pem.Encode(privKeyPEMBuffer, &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: b,
+	})
+
+	private, err := ssh.ParsePrivateKey(privKeyPEMBuffer.Bytes())
+	if err != nil {
+		log.Fatal("Failed to parse private key: ", err)
+	}
+
+	return private, nil
 }

--- a/internal/provider/port-scanner/scanner_test.go
+++ b/internal/provider/port-scanner/scanner_test.go
@@ -255,6 +255,7 @@ func Test_scanPort_Run_withSSHBastion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer sshBastionDialer.Close()
 
 	for result := range Run(sshBastionDialer, "127.0.0.1", 5959, 5959, DefaultTimeoutPerPort) {
 		if result.Port == port {


### PR DESCRIPTION
Sometimes ports aren't easily available for Terraform to scan, i.e. on the open internet. In this case, we optionally route traffic through an SSH bastion (via `direct-tcpip` channel type) to forward the connection.

## Example Usage

```hcl
variable "bastion_public_ip" {
  type        = string
  description = "SSH bastion public IP address"
}

variable "bastion_user" {
  type        = string
  description = "SSH bastion username"
}

variable "bastion_host_key" {
  type        = string
  description = "SSH bastion Base64 encoded host key"
}

variable "bastion_private_key" {
  type        = string
  description = "SSH bastion PEM encoded private key"
}

data "port_scan" "example" {
  ip_address = "192.168.0.2"
  ports      = [22, 443]

  ssh_bastion {
    user        = var.bastion_user
    ip_address  = var.bastion_public_ip
    private_key = var.bastion_private_key
    host_key    = var.bastion_host_key
  }
}

output "open_ports" {
  value = data.port_scan.example.open_ports
}
```

